### PR TITLE
Don't Crash on Request Error

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,7 +119,8 @@ func setupRouter() *gin.Engine {
 		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Fatal(err)
+			c.JSON(http.StatusBadGateway, nil)
+			return
 		}
 		bodyText, err := ioutil.ReadAll(resp.Body)
 		s := string(bodyText)


### PR DESCRIPTION
This patch prevents the application from crashing if the opencast server can not be reached, for example, due to a network outage.