### PR TITLE
Introduce Error Handling

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -12,24 +12,36 @@ fetch('/config')
 })
 
 /**
+ * Update the view
+ */
+function updateView(active) {
+	// Update text
+	document.getElementById('text').innerText = active.text;
+
+	// Update colors
+	const body = document.getElementsByTagName('body')[0];
+	body.style.backgroundColor = active.background;
+	body.style.color = active.color;
+
+	// Update logo
+	document.getElementById('logo').src = active.image.replace(/\s/g, '');
+}
+
+/**
  * Check for capture agent status
  */
 function updateTimer() {
 	fetch('/status')
-	.then(response => response.json())
-	.then(capturing => {
+	.then(response => {
+		if (!response.ok) {
+			const active = config.unknown;
+			active.text = response.statusText;
+			updateView(active);
+			throw Error(response.statusText);
+		}
+		return response.json()
+	}).then(capturing => {
 		console.debug('capturing', capturing)
-		const active = capturing ? config.capturing : config.idle;
-
-		// Update text
-		document.getElementById('text').innerText = active.text;
-
-		// Update colors
-		const body = document.getElementsByTagName('body')[0];
-		body.style.backgroundColor = active.background;
-		body.style.color = active.color;
-
-		// Update logo
-		document.getElementById('logo').src = active.image.replace(/\s/g, '');
+		updateView(capturing ? config.capturing : config.idle);
 	})
 }

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ type Config struct {
 	Display struct {
 		Capturing DisplayConfig `json:"capturing"`
 		Idle      DisplayConfig `json:"idle"`
+		Unknown   DisplayConfig `json:"unknown"`
 	}
 
 	Listen string
@@ -120,7 +121,13 @@ func setupRouter() *gin.Engine {
 		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
 		resp, err := client.Do(req)
 		if err != nil {
+			log.Println(err)
 			c.JSON(http.StatusBadGateway, nil)
+			return
+		}
+		if resp.StatusCode != 200 {
+			log.Println(resp)
+			c.JSON(resp.StatusCode, nil)
 			return
 		}
 		bodyText, err := ioutil.ReadAll(resp.Body)

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -110,6 +110,11 @@ display:
       bdf+Ja02rbN0Tm63v7bb1/63qhYAAAAAAAAAAAAAAAAAAAAAAAAAAIDY8w9T
       Gxe/25sMhQAAAABJRU5ErkJggg==
 
+  unknown:
+    text: Unknown
+    color: white
+    background: black
+
 
 # IP address and port to bind to
 listen: 127.0.0.1:8080


### PR DESCRIPTION
This patch introduces basic error handling. This ensures that errors are being logged and that the display reflects the error instead of just showing an inactive state.