### PR TITLE
Detailed display

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -8,6 +8,7 @@
 
 	<img id=logo />
 	<div id=text></div>
+	<div id=info></div>
 
 </body>
 </html>

--- a/assets/index.js
+++ b/assets/index.js
@@ -92,9 +92,9 @@ function parseCalendar(active){
 		console.debug('Calendar is empty');
 	}
 
-	hours = Math.floor(diff / (1000 * 60 * 60));
-	minutes = Math.floor((diff / (1000 * 60)) % 60);
-	seconds = Math.floor((diff / 1000) % 60);
+	hours = (diff > 0) ? Math.floor(diff / (1000 * 60 * 60)) : 0;
+	minutes = (diff > 0) ? Math.floor((diff / (1000 * 60)) % 60) : 0;
+	seconds = (diff > 0) ? Math.floor((diff / 1000) % 60) : 0;
 
 	hours = (hours < 10) ? '0' + hours : hours;
 	minutes = (minutes < 10) ? '0' + minutes : minutes;

--- a/assets/index.js
+++ b/assets/index.js
@@ -1,5 +1,5 @@
 var config = null;
-var calendar = updateCalendar();
+updateCalendar();
 var is_active = null;
 
 /**
@@ -47,50 +47,47 @@ function updateTimer() {
 		}
 		return response.json()
 	}).then(capturing => {
-		console.log('capturing', capturing);
-		if(is_active != capturing && !capturing){
-			updateCalendar()
-		}
+		console.debug('capturing', capturing);
 		is_active = capturing;
 		updateView(capturing ? config.capturing : config.idle);
 	})
 }
 
 function parseCalendar(active){
-	// Do we want 'Startet/Endet in' or 'Startet/Endet um'?
-	let diff = 0;
-	let t = 0;
+	let time_remaining = 0;
+	console.debug('Is Active? ', is_active);
+	const event_time = is_active ? calendar[0].End : calendar[0].Start;
 
 	now = Date.now();
 	if (calendar.length > 0){
-		t = is_active ? calendar[0].End : calendar[0].Start;
-		diff = t - now;
-		console.debug('Diff ', diff, t, now);
+		// TODO Maybe switch 'is_active' to 'capturing' here? 
+		//t = is_active ? calendar[0].End : calendar[0].Start;
+		time_remaining = event_time - now;
+		console.debug('Time Remaining: ', time_remaining, event_time, now);
 	} else {
 		console.debug('Calendar is empty');
-		
+		if(!is_active){
+			return active.none;
+		}
 	}
-
-	hours = (diff > 0) ? Math.floor(diff / (1000 * 60 * 60)) : 0;
-	minutes = (diff > 0) ? Math.floor((diff / (1000 * 60)) % 60) : 0;
-	seconds = (diff > 0) ? Math.floor((diff / 1000) % 60) : 0;
-
+	
+	hours = (time_remaining > 0) ? Math.floor(time_remaining / (1000 * 60 * 60)) : 0;
+	minutes = (time_remaining > 0) ? Math.floor((time_remaining / (1000 * 60)) % 60) : 0;
+	seconds = (time_remaining > 0) ? Math.floor((time_remaining / 1000) % 60) : 0;
+	
 	hours = (hours < 10) ? '0' + hours : hours;
 	minutes = (minutes < 10) ? '0' + minutes : minutes;
 	seconds = (seconds < 10) ? '0' + seconds : seconds;
-
-	console.debug('Remaining ', diff/1000);
-	if (calendar.length == 0 && !is_active) {
-		return 'Keine Aufzeichnung geplant';
-	} else {
-		return (hours > 0) ? active.info + ' ' + hours + ':' + minutes + ':' + seconds : active.info + ' ' + minutes + ':' + seconds;
-	}
+		
+	time_remaining = `${hours}:${minutes}:${seconds}`;
+	console.debug('Compare ', is_active, now, event_time);
+	return (is_active && now < calendar[0].Start) ? "" : active.info + ' ' + time_remaining;	
 }
 
 function updateCalendar() {
 	fetch("/calendar")
 	.then(response => {
-		console.debug('Calednar fetched; Status ', response.status)
+		console.debug('Calendar fetched; Status ', response.status);
 		return response.json()})
 	.then(json => {
 		console.log('Calendar ', json);

--- a/assets/index.js
+++ b/assets/index.js
@@ -16,16 +16,19 @@ fetch('/config')
  */
 function updateView(active) {
 	// Update text
-	document.getElementById('text').innerText = active.text;
+	document.getElementById('text').innerText = active ? config.capturing.text : config.idle.text;
 
 	// Update colors
 	const body = document.getElementsByTagName('body')[0];
-	body.style.backgroundColor = active.background;
-	body.style.color = active.color;
+	body.style.backgroundColor = active ? config.capturing.background : config.idle.background;
+	body.style.color = active? config.capturing.color : config.idle.color;
 
 	// Update logo
-	document.getElementById('logo').src = active.image.replace(/\s/g, '');
+	document.getElementById('logo').src = active ? config.capturing.image.replace(/\s/g, '') : config.idle.image.replace(/\s/g, '');
+
+	document.getElementById('info').innerText = getAdditionalInfo(active);
 }
+
 
 /**
  * Check for capture agent status
@@ -42,6 +45,90 @@ function updateTimer() {
 		return response.json()
 	}).then(capturing => {
 		console.debug('capturing', capturing)
-		updateView(capturing ? config.capturing : config.idle);
+		//updateView(capturing ? config.capturing : config.idle);
+		updateView(capturing);
 	})
+}
+
+function formatSeconds(s){
+	return (new Date(s * 1000)).toUTCString().match(/(\d\d:\d\d:\d\d)/)[0];
+}
+
+function parseCalendar(calendar, active){
+	//console.log('In parseCalendar ', calendar, active);
+	// Do we want 'Startet/Endet in' or 'Startet/Endet um'?
+	let diff = 0;
+	let t = 0;
+
+	console.log('Active ', active);
+	console.log('Lenght ', calendar.length);
+
+	now = Date.now();
+	try{
+		t = active ? Date.parse(calendar[0].data.endDate) : Date.parse(calendar[0].data.startDate);
+		diff = t - now;
+		console.log('Diff ', diff, t, now);
+	} catch (TypeError) {
+		console.debug('Calendar is empty');
+	}
+
+	let remaining = null;
+	console.log('Remaining ', new Date(diff/1000).toISOString());
+	remaining = formatSeconds(diff/1000)
+	if(calendar.length > 0){
+		return (active ? config.capturing.info : config.idle.info) + ' ' + remaining;
+	} else {
+		return (active ? config.capturing.info + ' ' + remaining : 'Keine Aufzeichnung geplant');
+	}
+}
+
+function getAdditionalInfo(active) {
+	// TODO find a better cutoff (24h ?)
+		/**
+		 * [ ] Task A: Updating the textbox 
+		 * 		[x] A1: Fetch the calendar
+		 * 		[x] A2: Parse the calendar according to the capturing status (either start or end date)
+		 *  	[ ] A3: Set the correct time remaining until end/next 
+		 * 			--> Check for capturing state, not changing for some reason
+		 * [ ] Task B: Retrieving the authentication details, the agent and the url
+		 * 	 	[ ] B1: read & parse yaml
+		 * 		[ ] B2: make a request with fetch 
+		 */
+
+	time = Date.now();
+	cutoff = time + 86400000; // Cutoff is set to 24h from now
+	
+	user = 'admin';
+	pw = 'opencast';
+	url = 'https://develop.opencast.org/recordings/calendar.json';
+	agent = 'test';
+
+	calendar = null;
+
+	let headers = new Headers();
+
+	headers.set('Authorization', 'Basic ' + btoa(user + ":" + pw));
+
+	url = url + '?' + new URLSearchParams({
+		agentid: agent,
+		cutoff: cutoff,
+	});
+
+	console.log('Request URL ', url);
+
+	fetch(url, {method:'GET',
+		headers:headers,
+	})
+	.then(response => {
+		console.debug('Status ', response.status)
+		return response.json()})
+	.then(json => {
+		console.debug('Calendar ', json);
+		calendar = json;
+		ans = parseCalendar(calendar, active);
+		console.debug('Ans ', ans);
+		return ans;
+	});
+	console.debug('Answer ', ans);
+	return String(ans);
 }

--- a/assets/index.js
+++ b/assets/index.js
@@ -67,7 +67,6 @@ function updateTimer() {
 		return response.json()
 	}).then(capturing => {
 		console.log('capturing', capturing);
-		// the second condition is not used for debugging
 		if(is_active != capturing && !capturing){
 			updateCalendar()
 		}
@@ -80,8 +79,6 @@ function parseCalendar(active){
 	// Do we want 'Startet/Endet in' or 'Startet/Endet um'?
 	let diff = 0;
 	let t = 0;
-	
-	console.debug('Calendar ', calendar);
 
 	now = Date.now();
 	if (calendar.length > 0){
@@ -102,14 +99,17 @@ function parseCalendar(active){
 	seconds = (seconds < 10) ? '0' + seconds : seconds;
 
 	console.debug('Remaining ', diff/1000);
-	console.log(diff, calendar.length, is_active);
-	return (calendar.length == 0 && !is_active) ? 'Keine Aufzeichnung geplant' : active.info + ' ' + hours + ':' + minutes + ':' + seconds;
+	if (calendar.length == 0 && !is_active) {
+		return 'Keine Aufzeichnung geplant';
+	} else {
+		return (hours > 0) ? active.info + ' ' + hours + ':' + minutes + ':' + seconds : active.info + ' ' + minutes + ':' + seconds;
+	}
 }
 
 function updateCalendar() {
 	fetch("/calendar")
 	.then(response => {
-		console.debug('Status ', response.status)
+		console.debug('Calednar fetched; Status ', response.status)
 		return response.json()})
 	.then(json => {
 		console.log('Calendar ', json);

--- a/assets/index.js
+++ b/assets/index.js
@@ -80,8 +80,8 @@ function parseCalendar(active){
 	// Do we want 'Startet/Endet in' or 'Startet/Endet um'?
 	let diff = 0;
 	let t = 0;
-
-	console.debug('Lenght ', calendar.length);
+	
+	console.debug('Calendar ', calendar);
 
 	now = Date.now();
 	if (calendar.length > 0){
@@ -90,6 +90,7 @@ function parseCalendar(active){
 		console.debug('Diff ', diff, t, now);
 	} else {
 		console.debug('Calendar is empty');
+		
 	}
 
 	hours = (diff > 0) ? Math.floor(diff / (1000 * 60 * 60)) : 0;
@@ -101,7 +102,8 @@ function parseCalendar(active){
 	seconds = (seconds < 10) ? '0' + seconds : seconds;
 
 	console.debug('Remaining ', diff/1000);
-	return calendar.length == 0 && !is_active ? 'Keine Aufzeichnung geplant' : active.info + ' ' + hours + ':' + minutes + ':' + seconds;
+	console.log(diff, calendar.length, is_active);
+	return (calendar.length == 0 && !is_active) ? 'Keine Aufzeichnung geplant' : active.info + ' ' + hours + ':' + minutes + ':' + seconds;
 }
 
 function updateCalendar() {

--- a/assets/index.js
+++ b/assets/index.js
@@ -3,25 +3,6 @@ var calendar = updateCalendar();
 var is_active = null;
 
 /**
- * [ ] Task A: Updating the textbox 
- * 		[ ] A1: Fetch the calendar from the correct Endpoint
- * 		[ ] A2: Parse the calendar according to the capturing status (either start or end date)
- *  	[ ] A3: Set the correct time remaining until end/next
- * [ ] Task B: Retrieving the authentication details, the agent and the url --> Backend
- * 	 	[ ] B1: read & parse yaml (?) Or is there a better way to do things? 
- * 		[ ] B2: make a request with fetch 
- * [x] Task C: Update the Calendar every two minutes (or something like that), not every 2 seconds
- * [ ] Task D: 
- * 
- * 
- * Kommentare von Lars:
- * 	- Falls in der nächsten (Viertel-)Stunde startet, so und so viel Minuten sonst einfach mit Datum
- *  - YAML im Backend auslesen und Opencast anfragen (alle 5 Minuten oder so)
- *  - Aus boolean ein json objekt machen ? Sonst zweiten Endpunkt machen
- *  - Statusfeld etwas nach oben verschieben, damit Display besser aussieht --> bessere Verteilung
- */
-
-/**
  * Load configuration and initialize timer
  */
 fetch('/config')

--- a/assets/style.css
+++ b/assets/style.css
@@ -25,3 +25,15 @@ body {
 	right: 5;
 	padding: 5vw;
 }
+
+#info {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	padding: 3vw;
+	font-size: 3vw;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -32,9 +32,9 @@ body {
 	align-items: center;
 	position: absolute;
 	top: 0;
-	bottom: 75;
 	left: 0;
 	right: 0;
 	padding: 3vw;
 	font-size: 3vw;
+	font-weight: 500;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -19,7 +19,7 @@ body {
 	justify-content: center;
 	align-items: center;
 	position: absolute;
-	top: 0;
+	top: 5vw;
 	bottom: 0;
 	left: 5;
 	right: 5;
@@ -31,7 +31,8 @@ body {
 	justify-content: center;
 	align-items: center;
 	position: absolute;
-	bottom: 0;
+	top: 0;
+	bottom: 75;
 	left: 0;
 	right: 0;
 	padding: 3vw;

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ type DisplayConfig struct {
 	Background string `json:"background"`
 	Image      string `json:"image"`
 	Info       string `json:"info"`
+	Empty      string `json:"none"`
 }
 
 type Config struct {
@@ -154,7 +155,7 @@ func setupRouter() *gin.Engine {
 	r.GET("/calendar", func(c *gin.Context) {
 		client := &http.Client{}
 		// Cutoff is set to 24 hours from now
-		cutoff := time.Now().UnixMilli() + int64(86400000)
+		cutoff := time.Now().UnixMilli() + 86400000
 		url := config.Opencast.Url + "/recordings/calendar.json?agentid=" + config.Opencast.Agent + "&cutoff=" + fmt.Sprint(cutoff) + "&timestamp=true"
 		req, err := http.NewRequest("GET", url, nil)
 		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
@@ -172,6 +173,7 @@ func setupRouter() *gin.Engine {
 
 		bodyText, err := io.ReadAll(resp.Body)
 		s := string([]byte(bodyText))
+
 		start := regexp.MustCompile(`"startDate":[\d]+`)
 		end := regexp.MustCompile(`"endDate":[\d]+`)
 		t := regexp.MustCompile(`"event.title":"[^"]+"`)

--- a/main.go
+++ b/main.go
@@ -180,17 +180,6 @@ func setupRouter() *gin.Engine {
 		endDates := end.FindAllString(s, -1)
 		titles := t.FindAllString(s, -1)
 
-		fmt.Println(startDates)
-		fmt.Println(endDates)
-		fmt.Println(titles)
-
-		fmt.Println(len(titles))
-
-		//reg := regexp.MustCompile(`"data":{".*?"recording":{}}`)
-		//result := reg.FindString(s)
-		//fmt.Println(result)
-		//fmt.Println("\n\n")
-		//j, err := json.Marshal(result)
 		cutoff_title := regexp.MustCompile(`"event.title":`)
 		cutoff_start := regexp.MustCompile(`"startDate":`)
 		cutoff_end := regexp.MustCompile(`"endDate":`)

--- a/main.go
+++ b/main.go
@@ -153,9 +153,9 @@ func setupRouter() *gin.Engine {
 
 	r.GET("/calendar", func(c *gin.Context) {
 		client := &http.Client{}
+		// Cutoff is set to 24 hours from now
 		cutoff := time.Now().UnixMilli() + int64(86400000)
 		url := config.Opencast.Url + "/recordings/calendar.json?agentid=" + config.Opencast.Agent + "&cutoff=" + fmt.Sprint(cutoff) + "&timestamp=true"
-		fmt.Print("\n" + url + "\n")
 		req, err := http.NewRequest("GET", url, nil)
 		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
 		resp, err := client.Do(req)
@@ -196,10 +196,8 @@ func setupRouter() *gin.Engine {
 		}
 
 		if len(titles) > 0 {
-			fmt.Println(fmt.Sprint(len(titles)) + " Events planned.")
 			c.JSON(http.StatusOK, events)
 		} else {
-			fmt.Println("No Events")
 			c.JSON(http.StatusOK, "")
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -44,9 +44,9 @@ type AgentStateResult struct {
 }
 
 type Event struct {
-	Title string
-	Start int
-	End   int
+	Title string `json:"title"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
 }
 
 type DisplayConfig struct {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type DisplayConfig struct {
 	Color      string `json:"color"`
 	Background string `json:"background"`
 	Image      string `json:"image"`
+	Info       string `json:"info"`
 }
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func setupRouter() *gin.Engine {
 			c.JSON(http.StatusOK, events)
 		} else {
 			fmt.Println("No Events")
-			c.JSON(http.StatusNoContent, "[]")
+			c.JSON(http.StatusOK, "")
 		}
 	})
 

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -54,6 +54,7 @@ display:
       HrhVPXVWTkn97VSgt/62FZZY0/33iOhe/l+Lb5X8k000WMtkiZpKH0S9QSaT
       OeiRdiQV+jtsszv4S0ehWoGoej5se96jOgMAAAAAAAAAAAAAAAAAAAAAuBD/
       AO9hftIMDgN8AAAAAElFTkSuQmCC
+    info: Aufzeichnung endet in
 
   idle:
     text: Keine Aufzeichnung
@@ -109,6 +110,7 @@ display:
       f4+spFz+r0VResjN9mzc3jXalThjwh+ybVHjPl+Xy+X60+fO9CjG+Gv5fn9N
       bdf+Ja02rbN0Tm63v7bb1/63qhYAAAAAAAAAAAAAAAAAAAAAAAAAAIDY8w9T
       Gxe/25sMhQAAAABJRU5ErkJggg==
+    info: Nächste Aufzeichnung in
 
   unknown:
     text: Unknown

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -111,6 +111,7 @@ display:
       bdf+Ja02rbN0Tm63v7bb1/63qhYAAAAAAAAAAAAAAAAAAAAAAAAAAIDY8w9T
       Gxe/25sMhQAAAABJRU5ErkJggg==
     info: Nächste Aufzeichnung in
+    empty: Keine Aufzeichnung geplant
 
   unknown:
     text: Unknown


### PR DESCRIPTION
Created an additional field to display the remaining time until the start of the next event if idle or the time until the end of the current recording if capturing.

An additional page for the backend was created which contains all planned events for the next 24 hours from the time of the request. The information for each event is the title, the start time (in ms) and the end time (also in ms).

