### PR TITLE
Expose version info and install time

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,11 @@ Next, go to the Opencast REST Docs → `/user-utils` and fill out the form for
 - roles: `["ROLE_CAPTURE_AGENT_CALENDAR"]`
 
 You should now be able to use this new user.
+
+## Creating a Release
+
+Creating a new release now involves multiple steps:
+
+1. Decide type of release => releases are named in the following form `v(majorVersion).(minorVersion).(patchVersion)`.
+2. Set the new release number in the `main.go` file (variables named accordingly in lines 41-43).
+3. Create the new release.

--- a/main.go
+++ b/main.go
@@ -187,8 +187,6 @@ var (
 	})
 )
 
-
-
 func loadConfig(configPath string) (*Config, error) {
 	// Open config file
 	yamlFile, err := os.ReadFile(configPath)

--- a/main.go
+++ b/main.go
@@ -125,6 +125,11 @@ type Config struct {
 		Prometheus bool
 		Listen     string
 	}
+
+	Version struct {
+		Version   string
+		Installed int64
+	}
 }
 
 var (
@@ -170,6 +175,20 @@ var (
 	}, []string{"state"})
 )
 
+var (
+	versionCollector = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "version_info",
+		Help: "Version information of the software",
+	}, []string{"version"})
+
+	installedCollector = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "installed_timestamp",
+		Help: "Timestamp when the software was installed",
+	})
+)
+
+
+
 func loadConfig(configPath string) (*Config, error) {
 	// Open config file
 	yamlFile, err := os.ReadFile(configPath)
@@ -199,6 +218,18 @@ func loadConfig(configPath string) (*Config, error) {
 	if config.Timeout == 0 {
 		// Timeout in Milliseconds
 		config.Timeout = 500
+	}
+
+	if config.Version.Version == "" {
+		config.Version.Version = "unknown"
+	}
+
+	// Set version metric
+	versionCollector.WithLabelValues(config.Version.Version).Set(1)
+
+	// Set installed timestamp metric
+	if config.Version.Installed > 0 {
+		installedCollector.Set(float64(config.Version.Installed))
 	}
 
 	return &config, nil
@@ -396,6 +427,8 @@ func setupRouter() *gin.Engine {
 func init() {
 	prometheus.MustRegister(stateCollector)
 	prometheus.MustRegister(timeCollector)
+	prometheus.MustRegister(versionCollector)
+	prometheus.MustRegister(installedCollector)
 }
 
 func setupMetricsRouter() *gin.Engine {

--- a/main.go
+++ b/main.go
@@ -37,6 +37,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const (
+	majorVersion = 0
+	minorVersion = 1
+	patchVersion = 3
+)
+
 type AgentStateResult struct {
 	Update struct {
 		Name  string
@@ -127,7 +133,6 @@ type Config struct {
 	}
 
 	Version struct {
-		Version   string
 		Installed int64
 	}
 }
@@ -157,6 +162,16 @@ func (c *myCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- s
 }
 
+type constCollector struct {
+	desc  *prometheus.Desc
+	value float64
+}
+
+func (c constCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.desc }
+func (c constCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, c.value)
+}
+
 var (
 	timeCollector = &myCollector{
 		metric: prometheus.NewDesc(
@@ -176,11 +191,38 @@ var (
 )
 
 var (
-	versionCollector = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "version_info",
-		Help: "Version information of the software",
-	}, []string{"version"})
+	versionCollectorMajor = constCollector{
+		desc: prometheus.NewDesc(
+			"version_info_major",
+			"Major Version number",
+			nil,
+			nil,
+		),
+		value: float64(majorVersion),
+	}
 
+	versionCollectorMinor = constCollector{
+		desc: prometheus.NewDesc(
+			"version_info_minor",
+			"Minor Version number",
+			nil,
+			nil,
+		),
+		value: float64(minorVersion),
+	}
+
+	versionCollectorPatch = constCollector{
+		desc: prometheus.NewDesc(
+			"version_info_patch",
+			"Patch Version number",
+			nil,
+			nil,
+		),
+		value: float64(patchVersion),
+	}
+)
+
+var (
 	installedCollector = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "installed_timestamp",
 		Help: "Timestamp when the software was installed",
@@ -217,13 +259,6 @@ func loadConfig(configPath string) (*Config, error) {
 		// Timeout in Milliseconds
 		config.Timeout = 500
 	}
-
-	if config.Version.Version == "" {
-		config.Version.Version = "unknown"
-	}
-
-	// Set version metric
-	versionCollector.WithLabelValues(config.Version.Version).Set(1)
 
 	// Set installed timestamp metric
 	if config.Version.Installed > 0 {
@@ -425,7 +460,9 @@ func setupRouter() *gin.Engine {
 func init() {
 	prometheus.MustRegister(stateCollector)
 	prometheus.MustRegister(timeCollector)
-	prometheus.MustRegister(versionCollector)
+	prometheus.MustRegister(versionCollectorMajor)
+	prometheus.MustRegister(versionCollectorMinor)
+	prometheus.MustRegister(versionCollectorPatch)
 	prometheus.MustRegister(installedCollector)
 }
 

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -132,5 +132,5 @@ metrics:
 version:
   # Application version
   version: 0.1.13
-  # Installation timestamp (unix epoch). If left blank, it will be set on first run
+  # Installation timestamp (unix epoch)
   installed: 1767962682

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -130,7 +130,5 @@ metrics:
   listen: 0.0.0.0:9100
 
 version:
-  # Application version
-  version: 0.1.13
   # Installation timestamp (unix epoch)
   installed: 1767962682

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -128,3 +128,9 @@ metrics:
   # Enable Prometheus metrics
   prometheus: true
   listen: 0.0.0.0:9100
+
+version:
+  # Application version
+  version: 0.1.13
+  # Installation timestamp (unix epoch). If left blank, it will be set on first run
+  installed: 1767962682


### PR DESCRIPTION
The version number and time of installation can now be set in the configuration file. The data is eposed in the node exporter unter the labels "version_info" and "installed_timestamp".