### PR TITLE
Split config loading and management into individual internal config package

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (conf *Config) LoadFromFile(path string) (*Config, error) {
+	yamlFile, err := os.ReadFile(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(yamlFile, &conf)
+
+	if err != nil {
+		return nil, err
+	}
+
+	conf.Serialize()
+
+	validation_err := conf.Validate()
+
+	if validation_err != nil {
+		return nil, validation_err
+	}
+
+	return conf, nil
+}

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -6,6 +6,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// LoadFromFile loads the configuration from a YAML file at the given path.
+// It validates and serializes the configuration after loading.
+// Returns the loaded Config or an error if loading, parsing, validation, or serialization fails.
 func (conf *Config) LoadFromFile(path string) (*Config, error) {
 	yamlFile, err := os.ReadFile(path)
 

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -29,6 +30,8 @@ func (conf *Config) LoadFromFile(path string) (*Config, error) {
 	if validation_err != nil {
 		return nil, validation_err
 	}
+
+	slog.Info("Finished loading configuration from file")
 
 	return conf, nil
 }

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -8,18 +8,18 @@ type OpencastConfig struct {
 }
 
 type DisplayStateConfig struct {
-	Text       string `yaml:"text"`
-	Color      string `yaml:"color"`
-	Background string `yaml:"background"`
-	Image      string `yaml:"image"`
-	Info       string `yaml:"info"`
-	Empty      string `yaml:"none"`
+	Text       string `yaml:"text" json:"text"`
+	Color      string `yaml:"color" json:"color"`
+	Background string `yaml:"background" json:"background"`
+	Image      string `yaml:"image" json:"image"`
+	Info       string `yaml:"info" json:"info"`
+	Empty      string `yaml:"none" json:"empty"`
 }
 
 type DisplayConfig struct {
-	Capturing DisplayStateConfig `yaml:"capturing"`
-	Idle      DisplayStateConfig `yaml:"idle"`
-	Unknown   DisplayStateConfig `yaml:"unknown"`
+	Capturing DisplayStateConfig `yaml:"capturing" json:"capturing"`
+	Idle      DisplayStateConfig `yaml:"idle" json:"idle"`
+	Unknown   DisplayStateConfig `yaml:"unknown" json:"unknown"`
 }
 
 type MetricsConfig struct {

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -1,0 +1,36 @@
+package config
+
+type OpencastConfig struct {
+	URL      string `yaml:"url"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+	Agent    string `yaml:"agent"`
+}
+
+type DisplayStateConfig struct {
+	Text       string `yaml:"text"`
+	Color      string `yaml:"color"`
+	Background string `yaml:"background"`
+	Image      string `yaml:"image"`
+	Info       string `yaml:"info"`
+	Empty      string `yaml:"none"`
+}
+
+type DisplayConfig struct {
+	Capturing DisplayStateConfig `yaml:"capturing"`
+	Idle      DisplayStateConfig `yaml:"idle"`
+	Unknown   DisplayStateConfig `yaml:"unknown"`
+}
+
+type MetricsConfig struct {
+	Enable bool   `yaml:"enable"`
+	Listen string `yaml:"listen"`
+}
+
+type Config struct {
+	Opencast OpencastConfig `yaml:"opencast"`
+	Display  DisplayConfig  `yaml:"display"`
+	Listen   string         `yaml:"listen"`
+	Timeout  int            `yaml:"timeout"`
+	Metrics  MetricsConfig  `yaml:"metrics"`
+}

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -23,7 +23,7 @@ type DisplayConfig struct {
 }
 
 type MetricsConfig struct {
-	Enable bool   `yaml:"enable"`
+	Enable bool   `yaml:"prometheus"` // is currently still controlled through prometheus, TODO: change in future
 	Listen string `yaml:"listen"`
 }
 

--- a/internal/config/serialize.go
+++ b/internal/config/serialize.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 )
 
+// serialize cleans up the Opencast configuration by trimming trailing slashes from the URL.
 func (oc_conf *OpencastConfig) serialize() {
 	oc_conf.URL = strings.Trim(oc_conf.URL, "/")
 }
 
+// serialize sets default values for Metrics configuration if not specified.
+// If Metrics are enabled but Listen is empty, it defaults to "0.0.0.0:9100".
 func (met_conf *MetricsConfig) serialize() {
 	if met_conf.Listen == "" && met_conf.Enable {
 		met_conf.Listen = "0.0.0.0:9100"
@@ -16,10 +19,16 @@ func (met_conf *MetricsConfig) serialize() {
 	}
 }
 
+// serialize performs serialization on Display configuration.
+// Currently a no-op (empty implementation).
 func (display_conf *DisplayConfig) serialize() {}
 
+// serialize performs serialization on DisplayState configuration.
+// Currently a no-op (empty implementation).
 func (display_state_conf *DisplayStateConfig) serialize() {}
 
+// Serialize performs serialization on all configuration sections.
+// It sets default values for Listen (127.0.0.1:8080) and Timeout (500) if not specified.
 func (conf *Config) Serialize() {
 	// Serialize opencast config
 	conf.Opencast.serialize()

--- a/internal/config/serialize.go
+++ b/internal/config/serialize.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"log/slog"
+	"strings"
+)
+
+func (oc_conf *OpencastConfig) serialize() {
+	oc_conf.URL = strings.Trim(oc_conf.URL, "/")
+}
+
+func (met_conf *MetricsConfig) serialize() {
+	if met_conf.Listen == "" && met_conf.Enable {
+		met_conf.Listen = "0.0.0.0:9100"
+		slog.Info("set metrics enpoit to default 0.0.0.0:9100")
+	}
+}
+
+func (display_conf *DisplayConfig) serialize() {}
+
+func (display_state_conf *DisplayStateConfig) serialize() {}
+
+func (conf *Config) Serialize() {
+	// Serialize opencast config
+	conf.Opencast.serialize()
+
+	// Serilaize Display config
+	conf.Display.serialize()
+
+	// Serialize metrics config
+	conf.Metrics.serialize()
+
+	if conf.Listen == "" {
+		conf.Listen = "127.0.0.1:8080"
+		slog.Info("set backend listen to default 127.0.0.1:8080")
+	}
+
+	if conf.Timeout <= 0 {
+		conf.Timeout = 500
+		slog.Info("set request timeout to a reasonable level")
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"errors"
+)
+
+func (oc_conf *OpencastConfig) validate() error {
+	if oc_conf.URL == "" {
+		return errors.New("Opencast: No Opencast server URL in configuration")
+	}
+	return nil
+}
+
+func (display_conf *DisplayConfig) validate() error {
+	return nil
+}
+
+func (disp_state_conf *DisplayStateConfig) validate() error {
+	return nil
+}
+
+func (metrics_conf *MetricsConfig) validate() error {
+	return nil
+}
+
+func (conf *Config) Validate() error {
+	opencast_err := conf.Opencast.validate()
+
+	display_err := conf.Display.validate()
+
+	metrics_err := conf.Metrics.validate()
+
+	var timeout_err error
+	if conf.Timeout <= 0 {
+		timeout_err = errors.New("the timeout can´t be zero or negative")
+	}
+
+	var listen_err error
+	if conf.Listen == "" {
+		listen_err = errors.New("it most be configured, where the main backend should listen on")
+	}
+
+	err := errors.Join(opencast_err, display_err, metrics_err, timeout_err, listen_err)
+
+	return err
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 )
 
+// validate checks if the Opencast configuration has a valid URL.
+// Returns an error if the URL is empty.
 func (oc_conf *OpencastConfig) validate() error {
 	if oc_conf.URL == "" {
 		return errors.New("Opencast: No Opencast server URL in configuration")
@@ -11,18 +13,28 @@ func (oc_conf *OpencastConfig) validate() error {
 	return nil
 }
 
+// validate checks if the Display configuration is valid.
+// Currently always returns nil (no validation implemented).
 func (display_conf *DisplayConfig) validate() error {
 	return nil
 }
 
+// validate checks if the DisplayState configuration is valid.
+// Currently always returns nil (no validation implemented).
 func (disp_state_conf *DisplayStateConfig) validate() error {
 	return nil
 }
 
+// validate checks if the Metrics configuration is valid.
+// Currently always returns nil (no validation implemented).
 func (metrics_conf *MetricsConfig) validate() error {
 	return nil
 }
 
+// Validate performs validation on all configuration sections.
+// It checks Opencast, Display, and Metrics configurations, as well as
+// the main timeout and listen settings.
+// Returns a combined error of all validation failures, or nil if all are valid.
 func (conf *Config) Validate() error {
 	opencast_err := conf.Opencast.validate()
 

--- a/main.go
+++ b/main.go
@@ -350,7 +350,7 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	slog.SetDefault(logger)
 
-	cConfig, err:= cConfig.LoadFromFile("opencast-ca-display.yml")
+	cConfig, err := cConfig.LoadFromFile("opencast-ca-display.yml")
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -81,15 +81,6 @@ type CalendarEntry struct {
 	EpisodeDublinCore string       `json:"episode-dublincore"`
 }
 
-// type DisplayConfig struct {
-// 	Text       string `json:"text"`
-// 	Color      string `json:"color"`
-// 	Background string `json:"background"`
-// 	Image      string `json:"image"`
-// 	Info       string `json:"info"`
-// 	Empty      string `json:"none"`
-// }
-
 type NetworkStatus struct {
 	Interfaces []NetInterface `json:"interfaces"`
 	Connected  bool           `json:"connected"`
@@ -102,29 +93,6 @@ type NetInterface struct {
 	MAC    string   `json:"mac_adress"`
 	Flags  string   `json:"flags"`
 }
-
-// type Config struct {
-// 	Opencast struct {
-// 		Url      string
-// 		Username string
-// 		Password string
-// 		Agent    string
-// 	}
-
-// 	Display struct {
-// 		Capturing DisplayConfig `json:"capturing"`
-// 		Idle      DisplayConfig `json:"idle"`
-// 		Unknown   DisplayConfig `json:"unknown"`
-// 	}
-
-// 	Listen  string
-// 	Timeout int
-
-// 	Metrics struct {
-// 		Prometheus bool
-// 		Listen     string
-// 	}
-// }
 
 var (
 	cConfig config.Config
@@ -168,40 +136,6 @@ var (
 		Help: "State of the CaptureAgent",
 	}, []string{"state"})
 )
-
-// func loadConfig(configPath string) (*config.Config, error) {
-// 	// Open config file
-// 	yamlFile, err := os.ReadFile(configPath)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	// Decode YAML file
-// 	if err := yaml.Unmarshal(yamlFile, &cConfig); err != nil {
-// 		return nil, err
-// 	}
-
-// 	// Ensure URL does not have trailing /
-// 	cConfig.Opencast.URL = strings.Trim(cConfig.Opencast.URL, "/")
-// 	if cConfig.Opencast.URL == "" {
-// 		return nil, errors.New("no Opencast server URL in configuration")
-// 	}
-
-// 	if cConfig.Listen == "" {
-// 		cConfig.Listen = "127.0.0.1:8080"
-// 	}
-
-// 	if cConfig.Metrics.Listen == "" {
-// 		cConfig.Metrics.Listen = "0.0.0.0:9100"
-// 	}
-
-// 	if cConfig.Timeout == 0 {
-// 		// Timeout in Milliseconds
-// 		cConfig.Timeout = 500
-// 	}
-
-// 	return &cConfig, nil
-// }
 
 func setupRouter() *gin.Engine {
 	r := gin.Default()

--- a/main.go
+++ b/main.go
@@ -19,19 +19,18 @@ package main
 import (
 	"embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
+	"opencast-ca-display/internal/config"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"gopkg.in/yaml.v3"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -82,14 +81,14 @@ type CalendarEntry struct {
 	EpisodeDublinCore string       `json:"episode-dublincore"`
 }
 
-type DisplayConfig struct {
-	Text       string `json:"text"`
-	Color      string `json:"color"`
-	Background string `json:"background"`
-	Image      string `json:"image"`
-	Info       string `json:"info"`
-	Empty      string `json:"none"`
-}
+// type DisplayConfig struct {
+// 	Text       string `json:"text"`
+// 	Color      string `json:"color"`
+// 	Background string `json:"background"`
+// 	Image      string `json:"image"`
+// 	Info       string `json:"info"`
+// 	Empty      string `json:"none"`
+// }
 
 type NetworkStatus struct {
 	Interfaces []NetInterface `json:"interfaces"`
@@ -104,31 +103,31 @@ type NetInterface struct {
 	Flags  string   `json:"flags"`
 }
 
-type Config struct {
-	Opencast struct {
-		Url      string
-		Username string
-		Password string
-		Agent    string
-	}
+// type Config struct {
+// 	Opencast struct {
+// 		Url      string
+// 		Username string
+// 		Password string
+// 		Agent    string
+// 	}
 
-	Display struct {
-		Capturing DisplayConfig `json:"capturing"`
-		Idle      DisplayConfig `json:"idle"`
-		Unknown   DisplayConfig `json:"unknown"`
-	}
+// 	Display struct {
+// 		Capturing DisplayConfig `json:"capturing"`
+// 		Idle      DisplayConfig `json:"idle"`
+// 		Unknown   DisplayConfig `json:"unknown"`
+// 	}
 
-	Listen  string
-	Timeout int
+// 	Listen  string
+// 	Timeout int
 
-	Metrics struct {
-		Prometheus bool
-		Listen     string
-	}
-}
+// 	Metrics struct {
+// 		Prometheus bool
+// 		Listen     string
+// 	}
+// }
 
 var (
-	config Config
+	cConfig config.Config
 
 	//go:embed assets
 	res embed.FS
@@ -170,39 +169,39 @@ var (
 	}, []string{"state"})
 )
 
-func loadConfig(configPath string) (*Config, error) {
-	// Open config file
-	yamlFile, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
+// func loadConfig(configPath string) (*config.Config, error) {
+// 	// Open config file
+// 	yamlFile, err := os.ReadFile(configPath)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	// Decode YAML file
-	if err := yaml.Unmarshal(yamlFile, &config); err != nil {
-		return nil, err
-	}
+// 	// Decode YAML file
+// 	if err := yaml.Unmarshal(yamlFile, &cConfig); err != nil {
+// 		return nil, err
+// 	}
 
-	// Ensure URL does not have trailing /
-	config.Opencast.Url = strings.Trim(config.Opencast.Url, "/")
-	if config.Opencast.Url == "" {
-		return nil, errors.New("no Opencast server URL in configuration")
-	}
+// 	// Ensure URL does not have trailing /
+// 	cConfig.Opencast.URL = strings.Trim(cConfig.Opencast.URL, "/")
+// 	if cConfig.Opencast.URL == "" {
+// 		return nil, errors.New("no Opencast server URL in configuration")
+// 	}
 
-	if config.Listen == "" {
-		config.Listen = "127.0.0.1:8080"
-	}
+// 	if cConfig.Listen == "" {
+// 		cConfig.Listen = "127.0.0.1:8080"
+// 	}
 
-	if config.Metrics.Listen == "" {
-		config.Metrics.Listen = "0.0.0.0:9100"
-	}
+// 	if cConfig.Metrics.Listen == "" {
+// 		cConfig.Metrics.Listen = "0.0.0.0:9100"
+// 	}
 
-	if config.Timeout == 0 {
-		// Timeout in Milliseconds
-		config.Timeout = 500
-	}
+// 	if cConfig.Timeout == 0 {
+// 		// Timeout in Milliseconds
+// 		cConfig.Timeout = 500
+// 	}
 
-	return &config, nil
-}
+// 	return &cConfig, nil
+// }
 
 func setupRouter() *gin.Engine {
 	r := gin.Default()
@@ -227,13 +226,13 @@ func setupRouter() *gin.Engine {
 
 	// Display Config
 	r.GET("/config", func(c *gin.Context) {
-		c.JSON(http.StatusOK, config.Display)
+		c.JSON(http.StatusOK, cConfig.Display)
 	})
 
 	// Status
 	r.GET("/status", func(c *gin.Context) {
-		client := &http.Client{Timeout: time.Duration(config.Timeout * int(time.Millisecond))}
-		url := config.Opencast.Url + "/capture-admin/agents/" + config.Opencast.Agent + ".json"
+		client := &http.Client{Timeout: time.Duration(cConfig.Timeout * int(time.Millisecond))}
+		url := cConfig.Opencast.URL + "/capture-admin/agents/" + cConfig.Opencast.Agent + ".json"
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			log.Println(err)
@@ -241,7 +240,7 @@ func setupRouter() *gin.Engine {
 			stateCollector.WithLabelValues("internal_server_error").Set(1)
 			return
 		}
-		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
+		req.SetBasicAuth(cConfig.Opencast.Username, cConfig.Opencast.Password)
 		resp, err := client.Do(req)
 		lastUpdate = time.Now()
 		if err != nil {
@@ -289,17 +288,17 @@ func setupRouter() *gin.Engine {
 	})
 
 	r.GET("/calendar", func(c *gin.Context) {
-		client := &http.Client{Timeout: time.Duration(config.Timeout * int(time.Millisecond))}
+		client := &http.Client{Timeout: time.Duration(cConfig.Timeout * int(time.Millisecond))}
 		// Cutoff is set to 24 hours from now
 		cutoff := time.Now().UnixMilli() + 86400000
-		url := config.Opencast.Url + "/recordings/calendar.json?agentid=" + config.Opencast.Agent + "&cutoff=" + fmt.Sprint(cutoff) + "&timestamp=true"
+		url := cConfig.Opencast.URL + "/recordings/calendar.json?agentid=" + cConfig.Opencast.Agent + "&cutoff=" + fmt.Sprint(cutoff) + "&timestamp=true"
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			log.Println(err)
 			c.JSON(http.StatusBadGateway, nil)
 			return
 		}
-		req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
+		req.SetBasicAuth(cConfig.Opencast.Username, cConfig.Opencast.Password)
 		resp, err := client.Do(req)
 		if err != nil {
 			if os.IsTimeout(err) {
@@ -368,15 +367,15 @@ func setupRouter() *gin.Engine {
 			inter := NetInterface{Name: net_inter.Name, MAC: net_inter.HardwareAddr.String(), Adress: addrs_str, Flags: net_inter.Flags.String()}
 			net_status.Interfaces = append(net_status.Interfaces, inter)
 		}
-		client := &http.Client{Timeout: time.Duration(config.Timeout * int(time.Millisecond))}
-		url := config.Opencast.Url
+		client := &http.Client{Timeout: time.Duration(cConfig.Timeout * int(time.Millisecond))}
+		url := cConfig.Opencast.URL
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			log.Println(err)
 			c.JSON(http.StatusBadGateway, nil)
 			return
 		}
-		// req.SetBasicAuth(config.Opencast.Username, config.Opencast.Password)
+		// req.SetBasicAuth(cConfig.Opencast.Username, cConfig.Opencast.Password)
 		_, err = client.Do(req)
 		if err != nil {
 			net_status.Connected = false
@@ -410,20 +409,29 @@ func setupMetricsRouter() *gin.Engine {
 }
 
 func main() {
-	if _, err := loadConfig("opencast-ca-display.yml"); err != nil {
+	// if _, err := loadConfig("opencast-ca-display.yml"); err != nil {
+	// 	log.Fatalf("Failed to load configuration: %v", err)
+	// }
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	slog.SetDefault(logger)
+
+	cConfig, err:= cConfig.LoadFromFile("opencast-ca-display.yml")
+	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
-	if config.Metrics.Prometheus {
+
+	if cConfig.Metrics.Enable {
 		go func() {
 			metricsRouter := setupMetricsRouter()
-			if err := metricsRouter.Run(config.Metrics.Listen); err != nil {
+			if err := metricsRouter.Run(cConfig.Metrics.Listen); err != nil {
 				log.Fatalf("Failed to run metrics server: %v", err)
 			}
 		}()
 	}
 
 	r := setupRouter()
-	if err := r.Run(config.Listen); err != nil {
+	if err := r.Run(cConfig.Listen); err != nil {
 		log.Fatalf("Failed to run server: %v", err)
 	}
 }

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -1,13 +1,13 @@
 opencast:
   # URL of the Opencast server to connect to
-  url: https://develop.opencast.org
+  url: https://stable.opencast.org
 
   # Uername and password of user with sufficient access to read agent status
   username: admin
   password: opencast
 
   # Capture agent to show the status for
-  agent: pyca@pyca-test.novalocal
+  agent: The_NLD
 
 # Display configuration
 # Each state configuration contains four fields:
@@ -122,7 +122,7 @@ display:
 # IP address and port to bind to
 listen: 127.0.0.1:8080
 # Variable Timout (sets to 500 Miliseconds if left blank)
-timeout: 500
+timeout: 1500
 
 metrics:
   # Enable Prometheus metrics


### PR DESCRIPTION
This pull request refactors the configuration management of the project by moving configuration logic from `main.go` into a new dedicated `internal/config` package. The new package provides structured configuration models, serialization (defaulting), and validation logic, leading to cleaner and more maintainable code. The main application now loads, serializes, and validates configuration using this package, and all references to configuration data in `main.go` are updated accordingly.

**Configuration Refactor and Improvements:**

* Introduced a new `internal/config` package with structured configuration models (`Config`, `OpencastConfig`, `DisplayConfig`, `MetricsConfig`, etc.), including YAML tags for file parsing.
* Added serialization logic in `serialize.go` to set default values (e.g., default listen address, timeout, metrics endpoint) and trim trailing slashes from URLs.
* Added validation logic in `validate.go` to ensure required configuration fields are present and valid (e.g., Opencast URL must not be empty, timeout must be positive).
* Implemented a `LoadFromFile` method in `main.go` to load, serialize, and validate configuration from a YAML file, replacing the previous hand-rolled loading logic. [[1]](diffhunk://#diff-16c37d0545834b2bbad59dde0d04a8a45007c9f669636d175c20bfa2539adf09R1-R37) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L173-R204) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L413-R434)

**Main Application Updates:**

* Updated all references in `main.go` to use the new `config.Config` struct (`cConfig`) instead of the old inline struct, and removed the old configuration struct definitions and loading logic. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L85-R91) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L107-R130) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L173-R204) [[4]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L230-R243) [[5]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L292-R301) [[6]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L371-R378) [[7]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L413-R434)

**Configuration File Changes:**

* Updated `opencast-ca-display.yml` example values for Opencast URL, agent, and timeout to reflect new defaults and test values. [[1]](diffhunk://#diff-9cbc6f3bc0d5f972ac30f0f85286b654c758fc166ed09654116a03a99cefeb93L3-R10) [[2]](diffhunk://#diff-9cbc6f3bc0d5f972ac30f0f85286b654c758fc166ed09654116a03a99cefeb93L125-R125)